### PR TITLE
test: add regression tests and fix component duplicate-detection bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .idea/
 *.tmp
 *.log
+coverage.out
+coverage.html

--- a/app_test.go
+++ b/app_test.go
@@ -181,3 +181,22 @@ func TestApp(t *testing.T) {
 		assert.Equal(t, "Hello", w.Body.String())
 	})
 }
+
+func TestAppSetServerNil(t *testing.T) {
+	t.Parallel()
+
+	assert.Panics(t, func() { New().SetServer(nil) })
+}
+
+func TestAppCloneNilTLSConfig(t *testing.T) {
+	t.Parallel()
+
+	// A fresh app has a nil TLSConfig; cloning must not panic and must
+	// preserve the nil TLSConfig (crypto/tls Clone handles nil receivers).
+	app := New()
+	assert.Nil(t, app.Server().TLSConfig)
+
+	var cloned *App
+	assert.NotPanics(t, func() { cloned = app.Clone() })
+	assert.Nil(t, cloned.Server().TLSConfig)
+}

--- a/config_test.go
+++ b/config_test.go
@@ -60,3 +60,39 @@ func TestConfig(t *testing.T) {
 		})
 	})
 }
+
+func TestConfigMerge(t *testing.T) {
+	t.Parallel()
+
+	// Multiple Config calls accumulate; colliding keys take the latest value.
+	app := New()
+	app.Config(AppConfig{
+		Globals: Globals{"a": "1"},
+		Routes:  Routes{"r1": "/1"},
+	})
+	app.Config(AppConfig{
+		Globals: Globals{"b": "2", "a": "1override"},
+		Routes:  Routes{"r2": "/2"},
+	})
+
+	assert.Equal(t, "1override", app.Global("a"))
+	assert.Equal(t, "2", app.Global("b"))
+	assert.Equal(t, "/1", app.Route("r1"))
+	assert.Equal(t, "/2", app.Route("r2"))
+}
+
+func TestConfigParseNilData(t *testing.T) {
+	t.Parallel()
+
+	app := New()
+	assert.NotPanics(t, func() { app.ParseConfig(nil) })
+	assert.Equal(t, 0, mapLen(&app.globals))
+	assert.Len(t, app.routes, 0)
+	assert.Len(t, app.template, 0)
+}
+
+func TestConfigParseConfigFileEmptyName(t *testing.T) {
+	t.Parallel()
+
+	assert.Panics(t, func() { New().ParseConfigFile("") })
+}

--- a/context_test.go
+++ b/context_test.go
@@ -856,3 +856,272 @@ func TestContext(t *testing.T) {
 		assert.Equal(t, "a=; Max-Age=0", w.Header()["Set-Cookie"][1])
 	})
 }
+
+func TestContextETagNon200(t *testing.T) {
+	t.Parallel()
+
+	// ETag is only computed for 200 responses.
+	app := hime.New()
+	app.ETag = true
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	ctx := hime.NewAppContext(app, w, r)
+
+	assert.NoError(t, ctx.Status(http.StatusCreated).JSON(map[string]any{"a": 1}))
+	assert.Equal(t, http.StatusCreated, w.Code)
+	assert.Empty(t, w.Header().Get("ETag"))
+}
+
+// etag304Case runs render once to capture the ETag, then re-runs with
+// If-None-Match and asserts a 304 with an empty body.
+func etag304Case(t *testing.T, render func(ctx *hime.Context) error) {
+	t.Helper()
+
+	app := hime.New()
+	app.ETag = true
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	ctx := hime.NewAppContext(app, w, r)
+	assert.NoError(t, render(ctx))
+	etag := w.Header().Get("ETag")
+	if !assert.NotEmpty(t, etag) {
+		return
+	}
+
+	w2 := httptest.NewRecorder()
+	r2 := httptest.NewRequest(http.MethodGet, "/", nil)
+	r2.Header.Set("If-None-Match", etag)
+	ctx2 := hime.NewAppContext(app, w2, r2)
+	assert.NoError(t, render(ctx2))
+	assert.Equal(t, http.StatusNotModified, w2.Code)
+	assert.Empty(t, w2.Body.String())
+}
+
+func TestContextETag304(t *testing.T) {
+	t.Parallel()
+
+	t.Run("JSON", func(t *testing.T) {
+		etag304Case(t, func(ctx *hime.Context) error {
+			return ctx.JSON(map[string]any{"a": 1})
+		})
+	})
+
+	t.Run("HTML", func(t *testing.T) {
+		etag304Case(t, func(ctx *hime.Context) error {
+			return ctx.HTML(`<h1>hi</h1>`)
+		})
+	})
+
+	t.Run("Render", func(t *testing.T) {
+		etag304Case(t, func(ctx *hime.Context) error {
+			return ctx.Render(`hello, {{.}}`, "world")
+		})
+	})
+}
+
+func TestContextComponentETag304(t *testing.T) {
+	t.Parallel()
+
+	app := hime.New()
+	app.ETag = true
+	app.Template().Component(template.Must(template.New("c").Parse(`component`)))
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	ctx := hime.NewAppContext(app, w, r)
+	assert.NoError(t, ctx.Component("c", nil))
+	etag := w.Header().Get("ETag")
+	if !assert.NotEmpty(t, etag) {
+		return
+	}
+
+	w2 := httptest.NewRecorder()
+	r2 := httptest.NewRequest(http.MethodGet, "/", nil)
+	r2.Header.Set("If-None-Match", etag)
+	ctx2 := hime.NewAppContext(app, w2, r2)
+	assert.NoError(t, ctx2.Component("c", nil))
+	assert.Equal(t, http.StatusNotModified, w2.Code)
+	assert.Empty(t, w2.Body.String())
+}
+
+func TestContextDelCookieWithOptions(t *testing.T) {
+	t.Parallel()
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	ctx := hime.NewAppContext(hime.New(), w, r)
+
+	ctx.DelCookie("session", &hime.CookieOptions{
+		Path:     "/admin",
+		Domain:   "example.com",
+		Secure:   true,
+		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
+	})
+
+	sc := w.Header().Get("Set-Cookie")
+	assert.Contains(t, sc, "session=")
+	assert.Contains(t, sc, "Max-Age=0")
+	assert.Contains(t, sc, "Path=/admin")
+	assert.Contains(t, sc, "Domain=example.com")
+	assert.Contains(t, sc, "Secure")
+	assert.Contains(t, sc, "HttpOnly")
+	assert.Contains(t, sc, "SameSite=Lax")
+}
+
+func TestContextAddCookieNilOptions(t *testing.T) {
+	t.Parallel()
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	ctx := hime.NewAppContext(hime.New(), w, r)
+
+	ctx.AddCookie("x", "y", nil)
+	assert.Equal(t, "x=y", w.Header().Get("Set-Cookie"))
+}
+
+func TestContextCookieValueMissing(t *testing.T) {
+	t.Parallel()
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	ctx := hime.NewAppContext(hime.New(), w, r)
+
+	assert.Equal(t, "", ctx.CookieValue("missing"))
+}
+
+func TestContextJSONError(t *testing.T) {
+	t.Parallel()
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	ctx := hime.NewAppContext(hime.New(), w, r)
+
+	assert.Error(t, ctx.JSON(make(chan int)))
+}
+
+func TestContextBindJSONInvalid(t *testing.T) {
+	t.Parallel()
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPost, "/", strings.NewReader("{invalid"))
+	ctx := hime.NewAppContext(hime.New(), w, r)
+
+	var v map[string]any
+	assert.Error(t, ctx.BindJSON(&v))
+}
+
+func TestContextFileNotFound(t *testing.T) {
+	t.Parallel()
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	ctx := hime.NewAppContext(hime.New(), w, r)
+
+	assert.NoError(t, ctx.File("testdata/does-not-exist.txt"))
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestContextRedirectInvalidURL(t *testing.T) {
+	t.Parallel()
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	ctx := hime.NewAppContext(hime.New(), w, r)
+
+	assert.Panics(t, func() { ctx.Redirect("%zz") })
+}
+
+func TestContextSafeRedirectDangerous(t *testing.T) {
+	t.Parallel()
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	ctx := hime.NewAppContext(hime.New(), w, r)
+
+	assert.NoError(t, ctx.SafeRedirect("https://evil.com/path"))
+	assert.Equal(t, "/path", w.Header().Get("Location"))
+}
+
+func TestContextStringFormat(t *testing.T) {
+	t.Parallel()
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	ctx := hime.NewAppContext(hime.New(), w, r)
+
+	assert.NoError(t, ctx.String("hello %s %d", "world", 42))
+	assert.Equal(t, "hello world 42", w.Body.String())
+}
+
+func TestContextSetContentTypeRespected(t *testing.T) {
+	t.Parallel()
+
+	// a pre-set Content-Type is not overridden by a write method
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	ctx := hime.NewAppContext(hime.New(), w, r)
+
+	ctx.SetHeader("Content-Type", "application/xml")
+	assert.NoError(t, ctx.HTML("<x/>"))
+	assert.Equal(t, "application/xml", w.Header().Get("Content-Type"))
+}
+
+func TestContextErrorStatusCode(t *testing.T) {
+	t.Parallel()
+
+	t.Run("preserves 4xx", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet, "/", nil)
+		ctx := hime.NewAppContext(hime.New(), w, r)
+
+		assert.NoError(t, ctx.Status(http.StatusUnauthorized).Error("nope"))
+		assert.Equal(t, http.StatusUnauthorized, w.Code)
+	})
+
+	t.Run("promotes <400 to 500", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet, "/", nil)
+		ctx := hime.NewAppContext(hime.New(), w, r)
+
+		assert.NoError(t, ctx.Status(http.StatusOK).Error("nope"))
+		assert.Equal(t, http.StatusInternalServerError, w.Code)
+	})
+}
+
+func TestContextRenderParseError(t *testing.T) {
+	t.Parallel()
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	ctx := hime.NewAppContext(hime.New(), w, r)
+
+	assert.Error(t, ctx.Render("{{.", nil))
+}
+
+func TestContextETagOverride(t *testing.T) {
+	t.Parallel()
+
+	t.Run("enable on a non-ETag app", func(t *testing.T) {
+		app := hime.New() // app.ETag defaults to false
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet, "/", nil)
+		ctx := hime.NewAppContext(app, w, r)
+
+		assert.NoError(t, ctx.ETag(true).JSON(map[string]any{"a": 1}))
+		assert.NotEmpty(t, w.Header().Get("ETag"))
+	})
+
+	t.Run("disable on an ETag app", func(t *testing.T) {
+		app := hime.New()
+		app.ETag = true
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet, "/", nil)
+		ctx := hime.NewAppContext(app, w, r)
+
+		assert.NoError(t, ctx.ETag(false).JSON(map[string]any{"a": 1}))
+		assert.Empty(t, w.Header().Get("ETag"))
+	})
+}

--- a/error_test.go
+++ b/error_test.go
@@ -23,3 +23,21 @@ func TestErrors(t *testing.T) {
 	assert.IsType(t, &ErrTemplateNotFound{}, err)
 	assert.Contains(t, err.Error(), "temp123")
 }
+
+func TestErrorMessages(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "hime: route 'r' not found", newErrRouteNotFound("r").Error())
+	assert.Equal(t, "hime: template 't' not found", newErrTemplateNotFound("t").Error())
+	assert.Equal(t, "hime: template 't' already exists", newErrTemplateDuplicate("t").Error())
+	assert.Equal(t, "hime: component 'c' not found", newErrComponentNotFound("c").Error())
+	assert.Equal(t, "hime: component 'c' already exists", newErrComponentDuplicate("c").Error())
+	assert.Equal(t, "hime: app not found", ErrAppNotFound.Error())
+}
+
+func TestPanicf(t *testing.T) {
+	t.Parallel()
+
+	// panicf prefixes "hime: " and formats the message.
+	assert.PanicsWithValue(t, "hime: bad value 42", func() { panicf("bad value %d", 42) })
+}

--- a/global_test.go
+++ b/global_test.go
@@ -1,6 +1,7 @@
 package hime
 
 import (
+	"context"
 	"net/http/httptest"
 	"testing"
 
@@ -63,4 +64,30 @@ func TestGlobal(t *testing.T) {
 			app.ServeHTTP(w, r)
 		})
 	})
+}
+
+func TestGlobalFuncWithoutApp(t *testing.T) {
+	assert.PanicsWithValue(t, ErrAppNotFound, func() {
+		Global(context.Background(), "key1")
+	})
+}
+
+func TestGlobalsMerge(t *testing.T) {
+	app := New()
+	app.Globals(Globals{"k1": "v1"})
+	app.Globals(Globals{"k2": "v2", "k1": "v1b"})
+
+	assert.Equal(t, "v1b", app.Global("k1"))
+	assert.Equal(t, "v2", app.Global("k2"))
+}
+
+func TestGlobalZeroValueVsMissing(t *testing.T) {
+	// Global discards the "found" boolean from sync.Map.Load, so a stored
+	// zero value and a missing key both surface as their natural value/nil.
+	app := New()
+	app.Globals(Globals{"empty": "", "zero": 0})
+
+	assert.Equal(t, "", app.Global("empty"))
+	assert.Equal(t, 0, app.Global("zero"))
+	assert.Nil(t, app.Global("missing"))
 }

--- a/handler_test.go
+++ b/handler_test.go
@@ -64,4 +64,42 @@ func TestHandler(t *testing.T) {
 			app.ServeHTTP(w, r)
 		})
 	})
+
+	t.Run("wrapped context.Canceled does not panic", func(t *testing.T) {
+		app := New()
+		app.Handler(Handler(func(ctx *Context) error {
+			return fmt.Errorf("operation failed: %w", context.Canceled)
+		}))
+
+		assert.NotPanics(t, func() {
+			invokeHandler(app, "GET", "/", nil)
+		})
+	})
+
+	t.Run("context.DeadlineExceeded panics", func(t *testing.T) {
+		// Only context.Canceled is swallowed; DeadlineExceeded is treated
+		// as a real error and panics.
+		app := New()
+		app.Handler(Handler(func(ctx *Context) error {
+			return context.DeadlineExceeded
+		}))
+
+		assert.Panics(t, func() {
+			invokeHandler(app, "GET", "/", nil)
+		})
+	})
+
+	t.Run("panic value is the returned error", func(t *testing.T) {
+		wantErr := fmt.Errorf("boom")
+		app := New()
+		app.Handler(Handler(func(ctx *Context) error {
+			return wantErr
+		}))
+
+		defer func() {
+			assert.Equal(t, wantErr, recover())
+		}()
+		invokeHandler(app, "GET", "/", nil)
+		t.Fatal("expected panic")
+	})
 }

--- a/map_test.go
+++ b/map_test.go
@@ -1,6 +1,11 @@
 package hime
 
-import "sync"
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
 
 func mapLen(m *sync.Map) (i int) {
 	m.Range(func(_, _ any) bool {
@@ -8,4 +13,27 @@ func mapLen(m *sync.Map) (i int) {
 		return true
 	})
 	return
+}
+
+func TestCloneMap(t *testing.T) {
+	t.Parallel()
+
+	var src sync.Map
+	src.Store("k1", "v1")
+	src.Store(2, "v2")
+
+	dst := cloneMap(&src)
+	assert.Equal(t, 2, mapLen(&dst))
+
+	v1, ok := dst.Load("k1")
+	assert.True(t, ok)
+	assert.Equal(t, "v1", v1)
+	v2, ok := dst.Load(2)
+	assert.True(t, ok)
+	assert.Equal(t, "v2", v2)
+
+	// clone is independent of the source
+	dst.Store("k3", "v3")
+	_, ok = src.Load("k3")
+	assert.False(t, ok)
 }

--- a/path_test.go
+++ b/path_test.go
@@ -85,3 +85,59 @@ func TestSafeRedirectPath(t *testing.T) {
 		assert.Equal(t, c.Output, SafeRedirectPath(c.Input))
 	}
 }
+
+func TestBuildPathInvalidURL(t *testing.T) {
+	t.Parallel()
+
+	// invalid percent-encoding makes url.Parse fail, which buildPath turns
+	// into a panic.
+	assert.Panics(t, func() { buildPath("%zz") })
+}
+
+func TestSafeRedirectPathInvalid(t *testing.T) {
+	t.Parallel()
+
+	// url.ParseRequestURI rejects the input, so SafeRedirectPath defaults to "/".
+	assert.Equal(t, "/", SafeRedirectPath("%zz"))
+}
+
+func TestSafeRedirectPathClean(t *testing.T) {
+	t.Parallel()
+
+	// SafeRedirectPath runs path.Clean, normalizing traversal sequences.
+	cases := []struct {
+		Input  string
+		Output string
+	}{
+		{"/a/../../etc/passwd", "/etc/passwd"},
+		{"/a/./b", "/a/b"},
+		{"/foo/..", "/"},
+	}
+	for _, c := range cases {
+		assert.Equal(t, c.Output, SafeRedirectPath(c.Input), "input: %s", c.Input)
+	}
+}
+
+func TestBuildPathParamMultiValue(t *testing.T) {
+	t.Parallel()
+
+	// Same query key from base and params is appended, not replaced.
+	assert.Equal(t, "/a?x=1&x=2", buildPath("/a?x=1", url.Values{"x": []string{"2"}}))
+	assert.Equal(t, "/a?x=1&x=2", buildPath("/a", map[string]string{"x": "1"}, map[string]string{"x": "2"}))
+}
+
+func TestBuildPathTraversalNotCleaned(t *testing.T) {
+	t.Parallel()
+
+	// Unlike SafeRedirectPath, buildPath uses path.Join (not path.Clean) for
+	// path params, so leading ".." segments are preserved.
+	assert.Equal(t, "/a/../../etc/passwd", buildPath("/a", "../../etc/passwd"))
+}
+
+func TestBuildPathZeroValues(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "/a?z=0", buildPath("/a", map[string]any{"z": 0}))
+	assert.Equal(t, "/a?z=false", buildPath("/a", map[string]any{"z": false}))
+	assert.Equal(t, "/a?z=%3Cnil%3E", buildPath("/a", map[string]any{"z": nil}))
+}

--- a/request_test.go
+++ b/request_test.go
@@ -5,6 +5,7 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -141,4 +142,55 @@ func TestRequest(t *testing.T) {
 			assert.Empty(t, h)
 		})
 	})
+}
+
+func TestRequestFormValueEdgeCases(t *testing.T) {
+	r := httptest.NewRequest("GET", "/?neg=-123&negc=-1,234&f=-3.14&sci=1e3&fstr=3.14&commas=,,&consec=1,,2", nil)
+	ctx := Context{Request: r}
+
+	assert.Equal(t, -123, ctx.FormValueInt("neg"))
+	assert.Equal(t, -1234, ctx.FormValueInt("negc"))
+	assert.Equal(t, int64(-1234), ctx.FormValueInt64("negc"))
+	assert.Equal(t, -3.14, ctx.FormValueFloat64("f"))
+	assert.Equal(t, float64(1000), ctx.FormValueFloat64("sci"))
+	assert.Equal(t, 0, ctx.FormValueInt("fstr")) // strconv.Atoi fails on "3.14", returns 0
+	assert.Equal(t, "", ctx.FormValueTrimSpaceComma("commas"))
+	assert.Equal(t, "12", ctx.FormValueTrimSpaceComma("consec"))
+}
+
+func TestRequestFormFileMissingKey(t *testing.T) {
+	b := bytes.Buffer{}
+	w := multipart.NewWriter(&b)
+	fw, _ := w.CreateFormFile("f1", "f1-name")
+	fw.Write([]byte("data"))
+	w.Close()
+
+	r := httptest.NewRequest("POST", "/", &b)
+	r.Header.Set("Content-Type", w.FormDataContentType())
+	ctx := Context{Request: r}
+
+	f, h, err := ctx.FormFileNotEmpty("missing")
+	assert.Equal(t, http.ErrMissingFile, err)
+	assert.Nil(t, f)
+	assert.Nil(t, h)
+
+	h2, err := ctx.FormFileHeader("missing")
+	assert.Equal(t, http.ErrMissingFile, err)
+	assert.Nil(t, h2)
+
+	h3, err := ctx.FormFileHeaderNotEmpty("missing")
+	assert.Equal(t, http.ErrMissingFile, err)
+	assert.Nil(t, h3)
+}
+
+func TestRequestFormFileHeaderParseError(t *testing.T) {
+	// A multipart Content-Type with a malformed body makes ParseMultipartForm
+	// fail, and FormFileHeader propagates that error.
+	r := httptest.NewRequest("POST", "/", strings.NewReader("not a valid multipart body"))
+	r.Header.Set("Content-Type", "multipart/form-data; boundary=xxx")
+	ctx := Context{Request: r}
+
+	h, err := ctx.FormFileHeader("f")
+	assert.Error(t, err)
+	assert.Nil(t, h)
 }

--- a/result_test.go
+++ b/result_test.go
@@ -1,10 +1,13 @@
 package hime
 
 import (
+	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"syscall"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -79,4 +82,29 @@ func TestPanicInView(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, resp.StatusCode, http.StatusInternalServerError)
 	})
+}
+
+func TestMatchETag(t *testing.T) {
+	t.Parallel()
+
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.Header.Set("If-None-Match", `W/"1-x", W/"5-abc", W/"10-y"`)
+
+	// matches any entry in the comma-separated list, tolerating whitespace
+	assert.True(t, matchETag(r, `W/"5-abc"`))
+	assert.True(t, matchETag(r, `W/"1-x"`))
+	assert.False(t, matchETag(r, `W/"5-zzz"`))
+}
+
+func TestFilterRenderError(t *testing.T) {
+	t.Parallel()
+
+	// connection-style errors are swallowed
+	assert.NoError(t, filterRenderError(nil))
+	assert.NoError(t, filterRenderError(&net.OpError{Op: "write", Err: errors.New("broken pipe")}))
+	assert.NoError(t, filterRenderError(syscall.EPIPE))
+
+	// real errors are propagated unchanged
+	realErr := errors.New("real error")
+	assert.Equal(t, realErr, filterRenderError(realErr))
 }

--- a/route_test.go
+++ b/route_test.go
@@ -1,7 +1,9 @@
 package hime
 
 import (
+	"context"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -96,5 +98,46 @@ func TestRoute(t *testing.T) {
 			}))
 			app.ServeHTTP(w, r)
 		})
+	})
+}
+
+func TestRouteWithParams(t *testing.T) {
+	app := New()
+	app.Routes(Routes{"user": "/user"})
+
+	assert.Equal(t, "/user?id=10", app.Route("user", url.Values{"id": []string{"10"}}))
+	assert.Equal(t, "/user?id=10", app.Route("user", map[string]string{"id": "10"}))
+	assert.Equal(t, "/user/10", app.Route("user", "10"))
+	assert.Equal(t, "/user?id=3", app.Route("user", &Param{Name: "id", Value: 3}))
+}
+
+func TestRoutesMerge(t *testing.T) {
+	app := New()
+	app.Routes(Routes{"a": "/1"})
+	app.Routes(Routes{"b": "/2"})
+	app.Routes(Routes{"a": "/3"})
+
+	assert.Equal(t, "/3", app.Route("a"))
+	assert.Equal(t, "/2", app.Route("b"))
+}
+
+func TestRouteNotFoundErrorType(t *testing.T) {
+	app := New()
+	app.Routes(Routes{"a": "/1"})
+
+	defer func() {
+		r := recover()
+		assert.IsType(t, &ErrRouteNotFound{}, r)
+		if err, ok := r.(error); assert.True(t, ok) {
+			assert.Contains(t, err.Error(), "route 'missing' not found")
+		}
+	}()
+	app.Route("missing")
+	t.Fatal("expected panic")
+}
+
+func TestRouteFuncWithoutApp(t *testing.T) {
+	assert.PanicsWithValue(t, ErrAppNotFound, func() {
+		Route(context.Background(), "x")
 	})
 }

--- a/server_test.go
+++ b/server_test.go
@@ -1,8 +1,10 @@
 package hime
 
 import (
+	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -17,4 +19,31 @@ func TestHTTPSRedirect(t *testing.T) {
 	r.Host = "localhost"
 	srv.Handler.ServeHTTP(w, r)
 	assert.Equal(t, w.Header().Get("Location"), "https://localhost/test")
+}
+
+func TestHTTPSRedirectServerConfig(t *testing.T) {
+	srv := HTTPSRedirect{Addr: ":9090"}.Server()
+
+	assert.Equal(t, ":9090", srv.Addr)
+	assert.Equal(t, 5*time.Second, srv.ReadTimeout)
+	assert.Equal(t, 5*time.Second, srv.WriteTimeout)
+	assert.NotNil(t, srv.Handler)
+}
+
+func TestHTTPSRedirectResponse(t *testing.T) {
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/test?a=1&b=2", nil)
+	r.Host = "example.com"
+
+	HTTPSRedirect{}.Server().Handler.ServeHTTP(w, r)
+
+	assert.Equal(t, http.StatusMovedPermanently, w.Code)
+	assert.Equal(t, "close", w.Header().Get("Connection"))
+	assert.Equal(t, "https://example.com/test?a=1&b=2", w.Header().Get("Location"))
+}
+
+func TestStartHTTPSRedirectServerInvalidAddr(t *testing.T) {
+	// An unparseable listen address makes ListenAndServe return immediately
+	// with an error instead of blocking.
+	assert.Error(t, StartHTTPSRedirectServer("bad:bad:bad"))
 }

--- a/template.go
+++ b/template.go
@@ -220,7 +220,7 @@ func (tp *Template) newTemplate(name string, parser func(t *template.Template) *
 }
 
 func (tp *Template) newComponent(name string, parser func(t *template.Template) *template.Template) {
-	if _, ok := tp.list[name]; ok {
+	if _, ok := tp.components[name]; ok {
 		panic(newErrComponentDuplicate(name))
 	}
 

--- a/template_test.go
+++ b/template_test.go
@@ -372,3 +372,86 @@ list:
 		assert.Len(t, cloneTmpl(map[string]*tmpl{"a": {}}), 1)
 	})
 }
+
+func TestTemplateComponentDuplicate(t *testing.T) {
+	t.Run("ParseComponent duplicate name panics", func(t *testing.T) {
+		tp := New().Template()
+		tp.ParseComponent("c", "first")
+		assert.Panics(t, func() { tp.ParseComponent("c", "second") })
+	})
+
+	t.Run("ParseComponentFile duplicate name panics", func(t *testing.T) {
+		tp := New().Template()
+		tp.Dir("testdata")
+		tp.ParseComponentFile("c", "component1.tmpl")
+		assert.Panics(t, func() { tp.ParseComponentFile("c", "component1.tmpl") })
+	})
+
+	t.Run("ParseComponent then Parse with same name are independent namespaces", func(t *testing.T) {
+		tp := New().Template()
+		tp.ParseComponent("x", "comp")
+		assert.NotPanics(t, func() { tp.Parse("x", "tmpl") })
+	})
+}
+
+func TestTemplateRenderComponent(t *testing.T) {
+	t.Run("renders registered component", func(t *testing.T) {
+		app := New()
+		app.Template().Component(template.Must(template.New("c").Parse(`hello, {{.}}`)))
+		assert.Equal(t, template.HTML("hello, hime"), app.renderComponent("c", "hime"))
+	})
+
+	t.Run("no data arg", func(t *testing.T) {
+		app := New()
+		app.Template().Component(template.Must(template.New("c").Parse(`static`)))
+		assert.Equal(t, template.HTML("static"), app.renderComponent("c"))
+	})
+
+	t.Run("not found panics", func(t *testing.T) {
+		app := New()
+		assert.Panics(t, func() { app.renderComponent("missing") })
+	})
+
+	t.Run("too many data args panics", func(t *testing.T) {
+		app := New()
+		app.Template().Component(template.Must(template.New("c").Parse(`x`)))
+		assert.Panics(t, func() { app.renderComponent("c", "a", "b") })
+	})
+
+	t.Run("execute error panics", func(t *testing.T) {
+		app := New()
+		app.Template().Component(template.Must(template.New("c").Parse(`{{.A.B}}`)))
+		assert.Panics(t, func() { app.renderComponent("c", map[string]any{"A": "not-a-struct"}) })
+	})
+}
+
+func TestTemplateConfigDelims(t *testing.T) {
+	// Config only applies Delims when exactly two are provided; otherwise
+	// the default {{ }} delimiters remain in effect.
+	t.Run("single delim is ignored", func(t *testing.T) {
+		tp := New().Template()
+		tp.Config(TemplateConfig{Delims: []string{"[["}})
+		tp.Parse("t", `{{ "x" }}`)
+
+		b := bytes.Buffer{}
+		assert.NoError(t, tp.list["t"].Execute(&b, nil))
+		assert.Equal(t, "x", b.String())
+	})
+}
+
+func TestTfParam(t *testing.T) {
+	assert.Equal(t, &Param{Name: "id", Value: 1}, tfParam("id", 1))
+}
+
+func TestTemplateComponentMultiple(t *testing.T) {
+	tp := New().Template()
+	tp.Component(
+		template.Must(template.New("c1").Parse(`one`)),
+		template.Must(template.New("c2").Parse(`two`)),
+	)
+	tp.Parse("t", `{{component "c1"}}-{{component "c2"}}`)
+
+	b := bytes.Buffer{}
+	assert.NoError(t, tp.list["t"].Execute(&b, nil))
+	assert.Equal(t, "one-two", b.String())
+}

--- a/tls_test.go
+++ b/tls_test.go
@@ -2,6 +2,7 @@ package hime
 
 import (
 	"crypto/tls"
+	"crypto/x509"
 	"fmt"
 	"net/http"
 	"testing"
@@ -178,4 +179,76 @@ func TestTLSConfig(t *testing.T) {
 	t.Run("Profile invalid", func(t *testing.T) {
 		assert.Panics(t, func() { (&TLS{Profile: "super-good"}).config() })
 	})
+}
+
+func TestParseTLSVersionSSL30AndCase(t *testing.T) {
+	assert.Equal(t, uint16(tls.VersionSSL30), parseTLSVersion("ssl3.0"))
+	assert.Equal(t, uint16(tls.VersionTLS12), parseTLSVersion("TLS1.2"))
+	assert.Equal(t, uint16(tls.VersionTLS13), parseTLSVersion("Tls1.3"))
+}
+
+func TestTLSProfilesDetail(t *testing.T) {
+	assert.Equal(t, uint16(tls.VersionTLS12), Restricted().MinVersion)
+	assert.Equal(t, uint16(tls.VersionTLS12), Modern().MinVersion)
+	assert.Equal(t, uint16(tls.VersionTLS10), Compatible().MinVersion)
+
+	assert.Len(t, Restricted().CipherSuites, 6)
+	assert.Len(t, Modern().CipherSuites, 10)
+	assert.Len(t, Compatible().CipherSuites, 15)
+
+	// only Compatible includes the legacy 3DES cipher
+	assert.Contains(t, Compatible().CipherSuites, uint16(tls.TLS_RSA_WITH_3DES_EDE_CBC_SHA))
+	assert.NotContains(t, Restricted().CipherSuites, uint16(tls.TLS_RSA_WITH_3DES_EDE_CBC_SHA))
+}
+
+func TestTLSConfigVersionOverride(t *testing.T) {
+	c := (&TLS{Profile: "modern", MinVersion: "tls1.3", MaxVersion: "tls1.3"}).config()
+	assert.Equal(t, uint16(tls.VersionTLS13), c.MinVersion)
+	assert.Equal(t, uint16(tls.VersionTLS13), c.MaxVersion)
+}
+
+func TestTLSConfigCurvesOverrideProfile(t *testing.T) {
+	c := (&TLS{Profile: "restricted", Curves: []string{"p384"}}).config()
+	assert.Equal(t, []tls.CurveID{tls.CurveP384}, c.CurvePreferences)
+}
+
+func TestTLSConfigEmptyProfile(t *testing.T) {
+	c := (&TLS{}).config()
+	assert.NotNil(t, c)
+	assert.Empty(t, c.CipherSuites)
+	assert.Equal(t, uint16(0), c.MinVersion)
+	assert.Equal(t, uint16(0), c.MaxVersion)
+}
+
+func TestSelfSignInvalidAlgo(t *testing.T) {
+	opt := &SelfSign{}
+	opt.Key.Algo = "invalid"
+	assert.EqualError(t, opt.config(&tls.Config{}), "invalid self-sign key algo 'invalid'")
+}
+
+func TestSelfSignInvalidSizeMessage(t *testing.T) {
+	opt := &SelfSign{}
+	opt.Key.Algo = "ecdsa"
+	opt.Key.Size = 999
+	assert.EqualError(t, opt.config(&tls.Config{}), "invalid self-sign key size '999'")
+}
+
+func TestSelfSignCertContents(t *testing.T) {
+	tc := tls.Config{}
+	opt := &SelfSign{CN: "example.com", Hosts: []string{"10.0.0.1", "::1", "example.com"}}
+
+	if assert.NoError(t, opt.config(&tc)) && assert.Len(t, tc.Certificates, 1) {
+		cert, err := x509.ParseCertificate(tc.Certificates[0].Certificate[0])
+		assert.NoError(t, err)
+		assert.Equal(t, "example.com", cert.Subject.CommonName)
+		assert.Len(t, cert.IPAddresses, 2)
+		assert.Len(t, cert.DNSNames, 1)
+		assert.Equal(t, "example.com", cert.DNSNames[0])
+	}
+}
+
+func TestLoadTLSCertKey(t *testing.T) {
+	c := &tls.Config{}
+	assert.NoError(t, loadTLSCertKey(c, "testdata/server.crt", "testdata/server.key"))
+	assert.Len(t, c.Certificates, 1)
 }


### PR DESCRIPTION
## Summary

This started as a "review tests and add regression coverage until confident" pass and surfaced a real production bug along the way.

### 🐛 Bug fix (`template.go`)
`Template.newComponent` checked the **templates** map (`tp.list`) instead of the **components** map (`tp.components`) for duplicate detection. As a result, registering two components with the same name via `ParseComponent` / `ParseComponentFile` **silently overwrote** the first instead of panicking with `ErrComponentDuplicate`.

The one-line fix makes it check `tp.components`, consistent with:
- `newTemplate`, which correctly checks `tp.list`, and
- the `Component()` loader, which already correctly checks `tp.components`.

Template and component namespaces are now independent (a template and a component may share a name; duplicates *within* each namespace panic). Confirmed via TDD: the new regression test fails against the old code and passes with the fix.

### ✅ Regression tests
Statement coverage **90.3% → 97.3%**. Highlights:

- **template**: component duplicate panic (the fix above), `renderComponent` paths, `Config` delims handling, `tfParam`
- **context**: ETag 304 for `JSON`/`HTML`/`Component`/`Render`, ETag skipped for non-200, per-context `ETag()` override, cookie option output, `JSON`/`BindJSON` errors, `File` 404, open-redirect safety, status-code logic
- **path**: `buildPath` invalid-URL panic; `SafeRedirectPath` `path.Clean` traversal normalization **vs** `buildPath`'s deliberately non-cleaning behavior (locks in the security-relevant difference)
- **tls**: profile `MinVersion`/cipher-suite lock-ins, version/curve overrides, `SelfSign` error messages and generated-certificate contents
- **request**: negative / comma / scientific-notation parsing, missing form files, malformed multipart
- **error / global / route / handler / server / config**: error-message formats, panic paths, merge semantics, wrapped `context.Canceled` vs `context.DeadlineExceeded`

The new tests were cross-checked by an adversarial review (correctness of expected values, no tautologies, bug-fix completeness, flakiness) — no correctness issues found.

## Test plan
- [x] `go vet ./...`
- [x] `go test ./...` (97.3% coverage)
- [x] `go test -race ./...`
- [x] `gofmt` clean

Also added `coverage.out` / `coverage.html` to `.gitignore`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)