### PR TITLE
feat: add XML/BindXML, StatusCode getter, and query-value helpers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,11 +36,11 @@ The key mechanism: `App.ServeHTTP` / `App.ServeHandler` wrap the downstream hand
 ### Context and result helpers (`context.go`, `request.go`)
 `Context` embeds `*http.Request` and itself implements `context.Context` (delegating to the request's context). Construct it with `NewContext(w, r)`.
 
-Response "results" are methods that write to the response and return `error` (meant to be returned from a `Handler`): `View`, `Component`, `Render`, `JSON`, `HTML`, `String`, `Bytes`, `CopyFrom`, `File`, `Redirect`/`SafeRedirect`/`RedirectTo`/`RedirectBack`, `Error`, `NotFound`, `NoContent`, `StatusText`. Status is set fluently via `ctx.Status(code)`.
+Response "results" are methods that write to the response and return `error` (meant to be returned from a `Handler`): `View`, `Component`, `Render`, `JSON`, `XML`, `HTML`, `String`, `Bytes`, `CopyFrom`, `File`, `Redirect`/`SafeRedirect`/`RedirectTo`/`RedirectBack`, `Error`, `NotFound`, `NoContent`, `StatusText`. Status is set fluently via `ctx.Status(code)` and read back via `ctx.StatusCode()`. Request bodies bind via `BindJSON`/`BindXML`.
 
-- **ETag**: when enabled (`App.ETag` or `ctx.ETag(true)`), `View`/`Component`/`Render`/`JSON`/`HTML` compute a weak ETag over the rendered bytes and return `304` on `If-None-Match` match (`setETag`). This forces buffering of output.
+- **ETag**: when enabled (`App.ETag` or `ctx.ETag(true)`), `View`/`Component`/`Render`/`JSON`/`XML`/`HTML` compute a weak ETag over the rendered bytes and return `304` on `If-None-Match` match (`setETag`). This forces buffering of output.
 - **`filterRenderError`** swallows broken-pipe / `net.OpError` / `EPIPE` errors so client disconnects aren't treated as handler failures.
-- `request.go` adds typed form helpers (`FormValueInt`, `PostFormValueFloat64`, etc.) that trim spaces and strip commas, plus `FormFileNotEmpty`/`FormFileHeader`.
+- `request.go` adds typed value helpers that trim spaces and strip commas, in three parallel families — `FormValue*` (query+body), `PostFormValue*` (body), and `QueryValue*` (query only) — plus multi-value slice getters (`FormValues`/`PostFormValues`/`QueryValues`) and `FormFileNotEmpty`/`FormFileHeader`.
 - Rendering buffers come from a shared `sync.Pool` in `pool.go` (`getBytes`/`putBytes`) — reuse it for any new buffered output.
 
 ### Templates and components (`template.go`)

--- a/context.go
+++ b/context.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha1"
 	"encoding/hex"
 	"encoding/json"
+	"encoding/xml"
 	"errors"
 	"fmt"
 	"html/template"
@@ -100,7 +101,9 @@ func (ctx *Context) Param(name string, value any) *Param {
 	return &Param{Name: name, Value: value}
 }
 
-func (ctx *Context) statusCode() int {
+// StatusCode returns the status code set via Status,
+// defaulting to http.StatusOK when none was set
+func (ctx *Context) StatusCode() int {
 	if ctx.code == 0 {
 		return http.StatusOK
 	}
@@ -125,7 +128,7 @@ func (ctx *Context) statusCodeError() int {
 }
 
 func (ctx *Context) writeHeader() {
-	ctx.w.WriteHeader(ctx.statusCode())
+	ctx.w.WriteHeader(ctx.StatusCode())
 }
 
 // ETag overrides etag setting
@@ -212,7 +215,7 @@ func (ctx *Context) NoContent() error {
 }
 
 func (ctx *Context) setETag(b []byte) bool {
-	if ctx.etag && ctx.statusCode() == http.StatusOK {
+	if ctx.etag && ctx.StatusCode() == http.StatusOK {
 		et := etag(b)
 		ctx.w.Header().Set("ETag", et)
 
@@ -355,6 +358,24 @@ func (ctx *Context) JSON(data any) error {
 	return ctx.CopyFrom(buf)
 }
 
+// XML encodes given data into xml then writes to response writer
+func (ctx *Context) XML(data any) error {
+	buf := getBytes()
+	defer putBytes(buf)
+
+	err := xml.NewEncoder(buf).Encode(data)
+	if err != nil {
+		return err
+	}
+
+	if ctx.setETag(buf.Bytes()) {
+		return nil
+	}
+
+	ctx.setContentType("application/xml; charset=utf-8")
+	return ctx.CopyFrom(buf)
+}
+
 // HTML writes html to response writer
 func (ctx *Context) HTML(data string) error {
 	if ctx.setETag([]byte(data)) {
@@ -377,7 +398,7 @@ func (ctx *Context) String(format string, a ...any) error {
 
 // StatusText writes status text from seted status code into response writer
 func (ctx *Context) StatusText() error {
-	return ctx.String("%s", http.StatusText(ctx.statusCode()))
+	return ctx.String("%s", http.StatusText(ctx.StatusCode()))
 }
 
 // CopyFrom copies src reader into response writer
@@ -429,6 +450,11 @@ func (ctx *Context) DelHeader(key string) {
 // BindJSON binds request body using json decoder
 func (ctx *Context) BindJSON(v any) error {
 	return json.NewDecoder(ctx.Body).Decode(v)
+}
+
+// BindXML binds request body using xml decoder
+func (ctx *Context) BindXML(v any) error {
+	return xml.NewDecoder(ctx.Body).Decode(v)
 }
 
 type CookieOptions struct {

--- a/context_test.go
+++ b/context_test.go
@@ -3,6 +3,7 @@ package hime_test
 import (
 	"bytes"
 	"context"
+	"encoding/xml"
 	"html/template"
 	"net/http"
 	"net/http/httptest"
@@ -919,6 +920,15 @@ func TestContextETag304(t *testing.T) {
 			return ctx.Render(`hello, {{.}}`, "world")
 		})
 	})
+
+	t.Run("XML", func(t *testing.T) {
+		etag304Case(t, func(ctx *hime.Context) error {
+			return ctx.XML(struct {
+				XMLName xml.Name `xml:"item"`
+				V       string   `xml:"v"`
+			}{V: "x"})
+		})
+	})
 }
 
 func TestContextComponentETag304(t *testing.T) {
@@ -1099,6 +1109,75 @@ func TestContextRenderParseError(t *testing.T) {
 	ctx := hime.NewAppContext(hime.New(), w, r)
 
 	assert.Error(t, ctx.Render("{{.", nil))
+}
+
+func TestContextXML(t *testing.T) {
+	t.Parallel()
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	ctx := hime.NewAppContext(hime.New(), w, r)
+
+	payload := struct {
+		XMLName xml.Name `xml:"item"`
+		Name    string   `xml:"name"`
+		Value   int      `xml:"value"`
+	}{Name: "hime", Value: 7}
+
+	assert.NoError(t, ctx.XML(payload))
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "application/xml; charset=utf-8", w.Header().Get("Content-Type"))
+	assert.Equal(t, "<item><name>hime</name><value>7</value></item>", w.Body.String())
+}
+
+func TestContextXMLError(t *testing.T) {
+	t.Parallel()
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	ctx := hime.NewAppContext(hime.New(), w, r)
+
+	// channels cannot be marshalled to xml
+	assert.Error(t, ctx.XML(make(chan int)))
+}
+
+func TestContextBindXML(t *testing.T) {
+	t.Parallel()
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`<item><name>hime</name></item>`))
+	ctx := hime.NewAppContext(hime.New(), w, r)
+
+	var body struct {
+		Name string `xml:"name"`
+	}
+	assert.NoError(t, ctx.BindXML(&body))
+	assert.Equal(t, "hime", body.Name)
+}
+
+func TestContextBindXMLInvalid(t *testing.T) {
+	t.Parallel()
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`<item><name>hime`))
+	ctx := hime.NewAppContext(hime.New(), w, r)
+
+	var body struct {
+		Name string `xml:"name"`
+	}
+	assert.Error(t, ctx.BindXML(&body))
+}
+
+func TestContextStatusCode(t *testing.T) {
+	t.Parallel()
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	ctx := hime.NewAppContext(hime.New(), w, r)
+
+	assert.Equal(t, http.StatusOK, ctx.StatusCode()) // default when unset
+	ctx.Status(http.StatusTeapot)
+	assert.Equal(t, http.StatusTeapot, ctx.StatusCode())
 }
 
 func TestContextETagOverride(t *testing.T) {

--- a/request.go
+++ b/request.go
@@ -84,6 +84,63 @@ func (ctx *Context) PostFormValueFloat64(key string) float64 {
 	return float64(x)
 }
 
+// QueryValueTrimSpace trims space from query value
+func (ctx *Context) QueryValueTrimSpace(key string) string {
+	return strings.TrimSpace(ctx.Request.URL.Query().Get(key))
+}
+
+// QueryValueTrimSpaceComma trims space and remove comma from query value
+func (ctx *Context) QueryValueTrimSpaceComma(key string) string {
+	return removeComma(strings.TrimSpace(ctx.Request.URL.Query().Get(key)))
+}
+
+// QueryValueInt converts query value to int
+func (ctx *Context) QueryValueInt(key string) int {
+	x, _ := strconv.Atoi(ctx.QueryValueTrimSpaceComma(key))
+	return x
+}
+
+// QueryValueInt64 converts query value to int64
+func (ctx *Context) QueryValueInt64(key string) int64 {
+	x, _ := strconv.ParseInt(ctx.QueryValueTrimSpaceComma(key), 10, 64)
+	return x
+}
+
+// QueryValueFloat32 converts query value to float32
+func (ctx *Context) QueryValueFloat32(key string) float32 {
+	x, _ := strconv.ParseFloat(ctx.QueryValueTrimSpaceComma(key), 32)
+	return float32(x)
+}
+
+// QueryValueFloat64 converts query value to float64
+func (ctx *Context) QueryValueFloat64(key string) float64 {
+	x, _ := strconv.ParseFloat(ctx.QueryValueTrimSpaceComma(key), 64)
+	return float64(x)
+}
+
+// FormValues returns all form values associated with the given key,
+// parsing the form first if necessary (query and body values)
+func (ctx *Context) FormValues(key string) []string {
+	if ctx.Request.Form == nil {
+		ctx.Request.ParseMultipartForm(defaultMaxMemory)
+	}
+	return ctx.Request.Form[key]
+}
+
+// PostFormValues returns all post form values associated with the given key,
+// parsing the form first if necessary (body values only)
+func (ctx *Context) PostFormValues(key string) []string {
+	if ctx.Request.PostForm == nil {
+		ctx.Request.ParseMultipartForm(defaultMaxMemory)
+	}
+	return ctx.Request.PostForm[key]
+}
+
+// QueryValues returns all query string values associated with the given key
+func (ctx *Context) QueryValues(key string) []string {
+	return ctx.Request.URL.Query()[key]
+}
+
 // FormFileNotEmpty returns file from r.FormFile
 // only when file size is not empty,
 // or return http.ErrMissingFile if file is empty

--- a/request_test.go
+++ b/request_test.go
@@ -183,6 +183,60 @@ func TestRequestFormFileMissingKey(t *testing.T) {
 	assert.Nil(t, h3)
 }
 
+func TestRequestQueryValue(t *testing.T) {
+	r := httptest.NewRequest("GET", "/?a=1&b=a%20b%20&c=1,234%20&neg=-12&f=-3.5", nil)
+	ctx := Context{Request: r}
+
+	assert.Equal(t, "1", ctx.QueryValueTrimSpace("a"))
+	assert.Equal(t, "a b", ctx.QueryValueTrimSpace("b"))
+	assert.Equal(t, "1,234", ctx.QueryValueTrimSpace("c"))
+	assert.Equal(t, "1234", ctx.QueryValueTrimSpaceComma("c"))
+
+	assert.Equal(t, 1, ctx.QueryValueInt("a"))
+	assert.Equal(t, 1234, ctx.QueryValueInt("c"))
+	assert.Equal(t, -12, ctx.QueryValueInt("neg"))
+	assert.Equal(t, 0, ctx.QueryValueInt("b")) // not a number
+
+	assert.Equal(t, int64(1234), ctx.QueryValueInt64("c"))
+	assert.Equal(t, float32(1), ctx.QueryValueFloat32("a"))
+	assert.Equal(t, float64(1234), ctx.QueryValueFloat64("c"))
+	assert.Equal(t, -3.5, ctx.QueryValueFloat64("f"))
+}
+
+func TestRequestValueSlices(t *testing.T) {
+	t.Run("FormValues and PostFormValues", func(t *testing.T) {
+		r := httptest.NewRequest("POST", "/?q=z", bytes.NewBufferString("a=1&a=2&b=3"))
+		r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		ctx := Context{Request: r}
+
+		assert.Equal(t, []string{"1", "2"}, ctx.FormValues("a"))
+		assert.Equal(t, []string{"1", "2"}, ctx.PostFormValues("a"))
+		assert.Equal(t, []string{"3"}, ctx.PostFormValues("b"))
+		// Form merges query + body; PostForm is body only
+		assert.Equal(t, []string{"z"}, ctx.FormValues("q"))
+		assert.Empty(t, ctx.PostFormValues("q"))
+		assert.Empty(t, ctx.FormValues("missing"))
+	})
+
+	t.Run("QueryValues", func(t *testing.T) {
+		r := httptest.NewRequest("GET", "/?a=1&a=2&b=3", nil)
+		ctx := Context{Request: r}
+
+		assert.Equal(t, []string{"1", "2"}, ctx.QueryValues("a"))
+		assert.Equal(t, []string{"3"}, ctx.QueryValues("b"))
+		assert.Empty(t, ctx.QueryValues("missing"))
+	})
+
+	t.Run("PostFormValues parses lazily", func(t *testing.T) {
+		// PostFormValues is the first form access, so it must trigger parsing
+		r := httptest.NewRequest("POST", "/", bytes.NewBufferString("x=1&x=2"))
+		r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		ctx := Context{Request: r}
+
+		assert.Equal(t, []string{"1", "2"}, ctx.PostFormValues("x"))
+	})
+}
+
 func TestRequestFormFileHeaderParseError(t *testing.T) {
 	// A multipart Content-Type with a malformed body makes ParseMultipartForm
 	// fail, and FormFileHeader propagates that error.


### PR DESCRIPTION
## Summary

Symmetry-completing helpers on `Context`, from the feature review. Every addition is a thin wrapper over the standard library — no new dependencies, no router/middleware/lock-in:

| Added | Mirrors | Notes |
|---|---|---|
| `XML(data) error` | `JSON()` | same pattern incl. ETag/304 support; `application/xml; charset=utf-8` |
| `BindXML(v) error` | `BindJSON()` | `xml.NewDecoder(ctx.Body).Decode` |
| `StatusCode() int` | `Status()` setter | returns the set code (200 default) |
| `QueryValue{TrimSpace,TrimSpaceComma,Int,Int64,Float32,Float64}` | `FormValue*` | query-only reads (explicit vs `FormValue`, which also reads the body) |
| `FormValues` / `PostFormValues` / `QueryValues` | `FormValue` singular | `[]string` for checkboxes / multi-select / repeated params |

`XML()` follows stdlib `encoding/xml` defaults (no `<?xml?>` declaration, no trailing newline), consistent with how `JSON()` uses `encoding/json`.

## Why these
They fill genuine asymmetries in hime's existing surface while staying true to its "thin layer over net/http, no lock-in" philosophy. Deliberately **not** included (would violate that philosophy): router, sessions, ORM, validation engine, forced middleware.

## Test plan
- [x] `go vet ./...`
- [x] `go test ./...` — package coverage 97.3% → 97.5%; **100%** on all 12 new functions
- [x] `go test -race ./...`
- [x] `gofmt` clean
- [x] `/scrutinize` pass — traced every new method end-to-end; no blockers/majors (one doc-wording nit on `StatusCode()` fixed in-branch)

CLAUDE.md updated to document the three parallel value families and the new response/bind helpers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)