### PR TITLE
feat: add opt-in signed cookies (CookieSigner + HMAC-SHA256)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,7 @@ Response "results" are methods that write to the response and return `error` (me
 - **ETag**: when enabled (`App.ETag` or `ctx.ETag(true)`), `View`/`Component`/`Render`/`JSON`/`XML`/`HTML` compute a weak ETag over the rendered bytes and return `304` on `If-None-Match` match (`setETag`). This forces buffering of output.
 - **`filterRenderError`** swallows broken-pipe / `net.OpError` / `EPIPE` errors so client disconnects aren't treated as handler failures.
 - `request.go` adds typed value helpers that trim spaces and strip commas, in three parallel families — `FormValue*` (query+body), `PostFormValue*` (body), and `QueryValue*` (query only) — plus multi-value slice getters (`FormValues`/`PostFormValues`/`QueryValues`) and `FormFileNotEmpty`/`FormFileHeader`.
+- `cookie.go` adds opt-in signed cookies: a `CookieSigner` interface plus an HMAC-SHA256 reference impl (`NewHMACCookieSigner`). Set `app.CookieSigner` (a public field, like `app.ETag`) to enable `AddSignedCookie`/`SignedCookieValue`, which read the signer off the app and panic if it's unset. The signer binds the cookie name into the MAC and verifies in constant time; it signs but does not encrypt. No lock-in — you supply your own signer.
 - Rendering buffers come from a shared `sync.Pool` in `pool.go` (`getBytes`/`putBytes`) — reuse it for any new buffered output.
 
 ### Templates and components (`template.go`)

--- a/app.go
+++ b/app.go
@@ -26,6 +26,10 @@ type App struct {
 	parent          *template.Template
 
 	ETag bool
+
+	// CookieSigner signs and verifies cookies for AddSignedCookie and
+	// SignedCookieValue. It is nil by default; set it to enable signed cookies.
+	CookieSigner CookieSigner
 }
 
 type ctxKeyApp struct{}
@@ -59,12 +63,13 @@ func (app *App) Clone() *App {
 			TLSConfig:          app.srv.TLSConfig.Clone(),
 			BaseContext:        app.srv.BaseContext,
 		},
-		handler:  app.handler,
-		routes:   cloneRoutes(app.routes),
-		globals:  cloneMap(&app.globals),
-		template: cloneTmpl(app.template),
-		parent:   template.Must(app.parent.Clone()),
-		ETag:     app.ETag,
+		handler:      app.handler,
+		routes:       cloneRoutes(app.routes),
+		globals:      cloneMap(&app.globals),
+		template:     cloneTmpl(app.template),
+		parent:       template.Must(app.parent.Clone()),
+		ETag:         app.ETag,
+		CookieSigner: app.CookieSigner,
 	}
 	x.srv.Handler = x
 	x.setupParent()

--- a/cookie.go
+++ b/cookie.go
@@ -1,0 +1,130 @@
+package hime
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"errors"
+	"strings"
+)
+
+// ErrInvalidCookie is returned by a CookieSigner when a signed cookie value is
+// malformed or fails verification.
+var ErrInvalidCookie = errors.New("hime: invalid signed cookie")
+
+// CookieSigner signs and verifies cookie values so tampering can be detected.
+//
+// Implementations must bind the cookie name into the signature (so a value
+// signed for one cookie can not be reused under a different name) and must use
+// a constant-time comparison when verifying.
+type CookieSigner interface {
+	// Sign returns the signed, encoded value to store in the cookie named name.
+	Sign(name, value string) (string, error)
+
+	// Verify checks signedValue for the cookie named name and returns the
+	// original value, or an error if it is malformed or fails verification.
+	Verify(name, signedValue string) (string, error)
+}
+
+// AddSignedCookie signs value with the app's CookieSigner and writes it as a
+// cookie. It is the signed counterpart of AddCookie; opts is applied the same
+// way. It panics if the app has no CookieSigner configured.
+func (ctx *Context) AddSignedCookie(name, value string, opts *CookieOptions) error {
+	signer := ctx.app.CookieSigner
+	if signer == nil {
+		panicf("no cookie signer configured")
+	}
+	signed, err := signer.Sign(name, value)
+	if err != nil {
+		return err
+	}
+	ctx.AddCookie(name, signed, opts)
+	return nil
+}
+
+// SignedCookieValue verifies the named cookie with the app's CookieSigner and
+// returns its value, or an empty string if the cookie is absent OR fails
+// verification (tampered, wrong key, or wrong name). The two cases are
+// intentionally indistinguishable — the safe default is to not trust the value
+// either way. If you need to tell them apart (for example to log tampering),
+// read the raw cookie with CookieValue and call the signer's Verify yourself.
+// It panics if the app has no CookieSigner configured.
+func (ctx *Context) SignedCookieValue(name string) string {
+	signer := ctx.app.CookieSigner
+	if signer == nil {
+		panicf("no cookie signer configured")
+	}
+	signed := ctx.CookieValue(name)
+	if signed == "" {
+		return ""
+	}
+	value, err := signer.Verify(name, signed)
+	if err != nil {
+		return ""
+	}
+	return value
+}
+
+// HMACCookieSigner is a CookieSigner backed by HMAC-SHA256. The cookie name is
+// bound into the signature and verification is constant time.
+//
+// It signs but does not encrypt: the value stays readable by the client. Serve
+// signed cookies as Secure + HttpOnly over HTTPS to protect them in transit,
+// and rely on cookie MaxAge for expiry (the signature itself never expires).
+//
+// Because the signature never expires on its own, rotating the key invalidates
+// every existing cookie. To rotate without logging users out, keep verifying
+// against the old key (try each signer in turn) until the old cookies' MaxAge
+// has elapsed.
+type HMACCookieSigner struct {
+	key []byte
+}
+
+// NewHMACCookieSigner returns an HMACCookieSigner using key (32+ random bytes
+// recommended). The key is copied, so the caller may reuse or zero its slice.
+// It panics if key is empty, since an empty key provides no protection.
+func NewHMACCookieSigner(key []byte) *HMACCookieSigner {
+	if len(key) == 0 {
+		panicf("cookie signer key must not be empty")
+	}
+	return &HMACCookieSigner{key: append([]byte(nil), key...)}
+}
+
+// mac computes HMAC-SHA256 over name, a NUL separator, then value. A cookie
+// name can not contain NUL, so this uniquely encodes the (name, value) pair and
+// binds the name into the signature.
+func (s *HMACCookieSigner) mac(name string, value []byte) []byte {
+	h := hmac.New(sha256.New, s.key)
+	h.Write([]byte(name))
+	h.Write([]byte{0})
+	h.Write(value)
+	return h.Sum(nil)
+}
+
+// Sign implements CookieSigner. The wire format is
+// base64url(value) "." base64url(mac).
+func (s *HMACCookieSigner) Sign(name, value string) (string, error) {
+	mac := s.mac(name, []byte(value))
+	return base64.RawURLEncoding.EncodeToString([]byte(value)) + "." +
+		base64.RawURLEncoding.EncodeToString(mac), nil
+}
+
+// Verify implements CookieSigner.
+func (s *HMACCookieSigner) Verify(name, signedValue string) (string, error) {
+	encValue, encMAC, ok := strings.Cut(signedValue, ".")
+	if !ok {
+		return "", ErrInvalidCookie
+	}
+	value, err := base64.RawURLEncoding.DecodeString(encValue)
+	if err != nil {
+		return "", ErrInvalidCookie
+	}
+	gotMAC, err := base64.RawURLEncoding.DecodeString(encMAC)
+	if err != nil {
+		return "", ErrInvalidCookie
+	}
+	if !hmac.Equal(gotMAC, s.mac(name, value)) {
+		return "", ErrInvalidCookie
+	}
+	return string(value), nil
+}

--- a/cookie_test.go
+++ b/cookie_test.go
@@ -1,0 +1,215 @@
+package hime_test
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/moonrhythm/hime"
+)
+
+var testCookieKey = []byte("0123456789abcdef0123456789abcdef") // 32 bytes
+
+// flipFirstByte returns s with its first byte changed, to simulate tampering.
+func flipFirstByte(s string) string {
+	b := []byte(s)
+	if b[0] == 'A' {
+		b[0] = 'B'
+	} else {
+		b[0] = 'A'
+	}
+	return string(b)
+}
+
+// readSetCookie returns the cookie with the given name from a recorded response.
+func readSetCookie(w *httptest.ResponseRecorder, name string) *http.Cookie {
+	for _, c := range w.Result().Cookies() {
+		if c.Name == name {
+			return c
+		}
+	}
+	return nil
+}
+
+func TestHMACCookieSigner(t *testing.T) {
+	t.Parallel()
+
+	signer := hime.NewHMACCookieSigner(testCookieKey)
+
+	t.Run("round trip", func(t *testing.T) {
+		t.Parallel()
+		signed, err := signer.Sign("session", "user42")
+		assert.NoError(t, err)
+		assert.NotEqual(t, "user42", signed) // value is encoded + signed
+
+		got, err := signer.Verify("session", signed)
+		assert.NoError(t, err)
+		assert.Equal(t, "user42", got)
+	})
+
+	t.Run("empty value round trips", func(t *testing.T) {
+		t.Parallel()
+		signed, err := signer.Sign("session", "")
+		assert.NoError(t, err)
+
+		got, err := signer.Verify("session", signed)
+		assert.NoError(t, err)
+		assert.Equal(t, "", got)
+	})
+
+	t.Run("binary-ish value round trips", func(t *testing.T) {
+		t.Parallel()
+		value := "a=b&c=d|e.f/g+h\x00\xff"
+		signed, err := signer.Sign("data", value)
+		assert.NoError(t, err)
+
+		got, err := signer.Verify("data", signed)
+		assert.NoError(t, err)
+		assert.Equal(t, value, got)
+	})
+
+	t.Run("tampered value fails", func(t *testing.T) {
+		t.Parallel()
+		signed, _ := signer.Sign("session", "user42")
+		_, err := signer.Verify("session", flipFirstByte(signed))
+		assert.ErrorIs(t, err, hime.ErrInvalidCookie)
+	})
+
+	t.Run("wrong key fails", func(t *testing.T) {
+		t.Parallel()
+		signed, _ := signer.Sign("session", "user42")
+		other := hime.NewHMACCookieSigner([]byte("ffffffffffffffffffffffffffffffff"))
+		_, err := other.Verify("session", signed)
+		assert.ErrorIs(t, err, hime.ErrInvalidCookie)
+	})
+
+	t.Run("name swap fails", func(t *testing.T) {
+		t.Parallel()
+		signed, _ := signer.Sign("session", "user42")
+		_, err := signer.Verify("other", signed) // name bound into the MAC
+		assert.ErrorIs(t, err, hime.ErrInvalidCookie)
+	})
+
+	t.Run("malformed fails", func(t *testing.T) {
+		t.Parallel()
+		for _, in := range []string{"", "nodot", "!!!.QQ", "QQ.!!!", "."} {
+			_, err := signer.Verify("session", in)
+			assert.ErrorIs(t, err, hime.ErrInvalidCookie, "input %q", in)
+		}
+	})
+
+	t.Run("empty key panics", func(t *testing.T) {
+		t.Parallel()
+		assert.Panics(t, func() { hime.NewHMACCookieSigner(nil) })
+		assert.Panics(t, func() { hime.NewHMACCookieSigner([]byte{}) })
+	})
+
+	t.Run("key is copied", func(t *testing.T) {
+		t.Parallel()
+		key := append([]byte(nil), testCookieKey...)
+		s := hime.NewHMACCookieSigner(key)
+		signed, _ := s.Sign("session", "user42")
+
+		for i := range key { // mutate the caller's slice after construction
+			key[i] = 0
+		}
+
+		got, err := s.Verify("session", signed)
+		assert.NoError(t, err)
+		assert.Equal(t, "user42", got)
+	})
+}
+
+func TestContextSignedCookie(t *testing.T) {
+	t.Parallel()
+
+	// signer used to generate signed values in tests; the app under test gets
+	// an independent signer with the same key, so the two are compatible.
+	signer := hime.NewHMACCookieSigner(testCookieKey)
+	newApp := func() *hime.App {
+		app := hime.New()
+		app.CookieSigner = hime.NewHMACCookieSigner(testCookieKey)
+		return app
+	}
+
+	t.Run("round trip through request and response", func(t *testing.T) {
+		t.Parallel()
+		app := newApp()
+
+		w := httptest.NewRecorder()
+		ctx := hime.NewAppContext(app, w, httptest.NewRequest(http.MethodGet, "/", nil))
+		assert.NoError(t, ctx.AddSignedCookie("session", "user42", &hime.CookieOptions{Path: "/"}))
+
+		c := readSetCookie(w, "session")
+		if !assert.NotNil(t, c) {
+			return
+		}
+		assert.NotEqual(t, "user42", c.Value) // stored value is signed
+
+		r := httptest.NewRequest(http.MethodGet, "/", nil)
+		r.AddCookie(c)
+		ctx2 := hime.NewAppContext(app, httptest.NewRecorder(), r)
+		assert.Equal(t, "user42", ctx2.SignedCookieValue("session"))
+	})
+
+	t.Run("missing cookie returns empty", func(t *testing.T) {
+		t.Parallel()
+		ctx := hime.NewAppContext(newApp(), httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/", nil))
+		assert.Equal(t, "", ctx.SignedCookieValue("session"))
+	})
+
+	t.Run("tampered cookie returns empty", func(t *testing.T) {
+		t.Parallel()
+		signed, _ := signer.Sign("session", "user42")
+		r := httptest.NewRequest(http.MethodGet, "/", nil)
+		r.AddCookie(&http.Cookie{Name: "session", Value: flipFirstByte(signed)})
+		ctx := hime.NewAppContext(newApp(), httptest.NewRecorder(), r)
+		assert.Equal(t, "", ctx.SignedCookieValue("session"))
+	})
+
+	t.Run("value moved to another cookie name returns empty", func(t *testing.T) {
+		t.Parallel()
+		signed, _ := signer.Sign("session", "user42")
+		r := httptest.NewRequest(http.MethodGet, "/", nil)
+		r.AddCookie(&http.Cookie{Name: "other", Value: signed})
+		ctx := hime.NewAppContext(newApp(), httptest.NewRecorder(), r)
+		assert.Equal(t, "", ctx.SignedCookieValue("other"))
+	})
+
+	t.Run("clone carries the signer", func(t *testing.T) {
+		t.Parallel()
+		clone := newApp().Clone()
+		ctx := hime.NewAppContext(clone, httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/", nil))
+		assert.NoError(t, ctx.AddSignedCookie("session", "x", nil)) // no panic => signer present
+	})
+
+	t.Run("AddSignedCookie propagates signer error", func(t *testing.T) {
+		t.Parallel()
+		app := hime.New()
+		app.CookieSigner = failingSigner{}
+		ctx := hime.NewAppContext(app, httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/", nil))
+		assert.Error(t, ctx.AddSignedCookie("session", "user42", nil))
+	})
+
+	t.Run("no signer configured panics", func(t *testing.T) {
+		t.Parallel()
+		ctx := hime.NewAppContext(hime.New(), httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/", nil))
+		assert.Panics(t, func() { ctx.AddSignedCookie("session", "x", nil) })
+		assert.Panics(t, func() { ctx.SignedCookieValue("session") })
+	})
+}
+
+// failingSigner is an external CookieSigner implementation used to confirm the
+// interface is usable by callers and that Sign errors propagate.
+type failingSigner struct{}
+
+func (failingSigner) Sign(name, value string) (string, error) {
+	return "", errors.New("sign failed")
+}
+
+func (failingSigner) Verify(name, signedValue string) (string, error) {
+	return "", errors.New("verify failed")
+}

--- a/example_test.go
+++ b/example_test.go
@@ -149,3 +149,19 @@ func ExampleSafeRedirectPath() {
 	fmt.Println(hime.SafeRedirectPath("https://evil.example.com/account"))
 	// Output: /account
 }
+
+func ExampleHMACCookieSigner() {
+	signer := hime.NewHMACCookieSigner([]byte("a-32-byte-or-longer-secret-key!!"))
+
+	signed, _ := signer.Sign("session", "user42")
+	value, err := signer.Verify("session", signed)
+	fmt.Println(value, err == nil)
+
+	// the cookie name is bound into the signature, so reusing the value
+	// under a different name fails verification
+	_, err = signer.Verify("other", signed)
+	fmt.Println(err)
+	// Output:
+	// user42 true
+	// hime: invalid signed cookie
+}


### PR DESCRIPTION
## Summary

Adds tamper-evident cookies (the deferred Tier-2 item from the feature review), with no lock-in. The signer is injected on the `App` (like `app.ETag`), so the methods mirror the plain cookie API exactly:

```go
app.CookieSigner = hime.NewHMACCookieSigner(secretKey) // 32+ random bytes

ctx.AddSignedCookie("session", userID, &hime.CookieOptions{
    Path: "/", HttpOnly: true, Secure: true, SameSite: http.SameSiteLaxMode,
})

userID := ctx.SignedCookieValue("session") // "" if absent or tampered
```

- **`CookieSigner`** interface (`Sign`/`Verify`) — callers can bring their own implementation.
- **`HMACCookieSigner`** reference impl via `NewHMACCookieSigner(key)` — HMAC-SHA256, stdlib only.
- **`App.CookieSigner`** field injects the signer; `Clone` carries it.
- **`Context.AddSignedCookie`** / **`SignedCookieValue`** — signed counterparts of `AddCookie`/`CookieValue`; they read the signer off the app and **panic if it's unset**.
- **`ErrInvalidCookie`** — single sentinel for all verification failures.

## Security properties
- **Name-bound MAC** — `HMAC(key, name ‖ 0x00 ‖ value)`. Cookie names can't contain NUL, so the encoding is injective: a value signed for one cookie can't be replayed under another name.
- **Constant-time** verification (`hmac.Equal`).
- **Defensive key copy**; `NewHMACCookieSigner` **panics on an empty key**.
- **Wire format** `base64url(value).base64url(mac)` — survives `http.SetCookie`/`Request.Cookie` unquoted.
- Signs but **does not encrypt** (value stays readable); docstrings cover that, key rotation, and absent-vs-tampered indistinguishability.

## How it was built
- **Design panel** (3 variants → judge synthesis) settled the API and name-binding; hardened with NUL-separated MAC input, `RawURLEncoding`, single sentinel error.
- **Adversarial security review** (crypto / encoding-tamper / api-misuse / net-http lenses): crypto, encoding, and net/http integration came back **sound**; doc-level findings addressed.
- **/scrutinize**: surfaced the empty-key foot-gun, now guarded with a panic + test.
- Final revision moves the signer from a per-call argument to `app.CookieSigner` for cleaner call sites; the crypto core is unchanged from the reviewed version.

## Test plan
- [x] `go vet ./...`
- [x] `go test ./...` — **100%** coverage on `cookie.go` and `Clone`
- [x] `go test -race ./...`
- [x] `gofmt` clean
- [x] runnable `ExampleHMACCookieSigner`; CLAUDE.md updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)