### PR TITLE
feat: add dict/json template funcs and RenderComponentToString

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,7 @@ Three distinct rendering concepts, all built from `app.parent` (a base `*templat
 2. **Components** (`app.component`) — reusable fragments rendered by `ctx.Component(name, data)` or inside templates via the `{{component "name" .}}` func. Loaded via `ParseComponent*` / `Component`.
 3. **Ad-hoc** — `ctx.Render(tmplText, data)` parses raw template text on the fly, **caching the parsed result** in `app.cachedComponent` (keyed by sha1+len of the text).
 
-Built-in template funcs registered on `parent` (`setupParent`): `param`, `templateName`, `component`, `route`, `global`. Optional HTML/CSS/JS minification via `github.com/tdewolff/minify/v2` is enabled with `Template().Minify()` and applied at execute time (`tmpl.Execute`). Loading a duplicate template/component name panics.
+Built-in template funcs registered on `parent` (`setupParent`): `param`, `templateName`, `component`, `route`, `global`, `dict` (build a map for multi-value component args, since `html/template` has no map literal), and `json` (marshal to `template.JS` for inline `<script>` data). `ctx.RenderComponentToString` renders a component to a string for composing responses (e.g. htmx out-of-band swaps). Optional HTML/CSS/JS minification via `github.com/tdewolff/minify/v2` is enabled with `Template().Minify()` and applied at execute time (`tmpl.Execute`). Loading a duplicate template/component name panics.
 
 ### Routes and globals (`route.go`, `global.go`)
 - **Routes**: a `name → path` map. Register with `app.Routes(...)`; resolve with `app.Route(name, params...)`, `ctx.Route(...)`, `ctx.RedirectTo(...)`, the `route` template func, or package-level `hime.Route(ctx, ...)`. A missing route **panics** (`ErrRouteNotFound`).

--- a/app.go
+++ b/app.go
@@ -179,6 +179,8 @@ func (app *App) setupParent() {
 		"component":    app.renderComponent,
 		"route":        app.Route,
 		"global":       app.Global,
+		"dict":         tfDict,
+		"json":         tfJSON,
 	})
 }
 

--- a/context.go
+++ b/context.go
@@ -274,6 +274,25 @@ func (ctx *Context) Component(name string, data any) error {
 	return ctx.CopyFrom(buf)
 }
 
+// RenderComponentToString renders the named component to a string instead of
+// writing it to the response, for composing responses (such as htmx
+// out-of-band swaps) from several components. It panics if the component is not
+// found, matching Component.
+func (ctx *Context) RenderComponentToString(name string, data any) (string, error) {
+	t, ok := ctx.app.component[name]
+	if !ok {
+		panic(newErrComponentNotFound(name))
+	}
+
+	buf := getBytes()
+	defer putBytes(buf)
+
+	if err := t.Execute(buf, data); err != nil {
+		return "", err
+	}
+	return buf.String(), nil
+}
+
 // Render renders html template
 func (ctx *Context) Render(tmpl string, data any) error {
 	hash := sha1.Sum([]byte(tmpl))

--- a/context_test.go
+++ b/context_test.go
@@ -1180,6 +1180,25 @@ func TestContextStatusCode(t *testing.T) {
 	assert.Equal(t, http.StatusTeapot, ctx.StatusCode())
 }
 
+func TestContextRenderComponentToString(t *testing.T) {
+	t.Parallel()
+
+	app := hime.New()
+	app.Template().Component(template.Must(template.New("badge").Parse(`<b>{{.}}</b>`)))
+	ctx := hime.NewAppContext(app, httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/", nil))
+
+	s, err := ctx.RenderComponentToString("badge", "new")
+	assert.NoError(t, err)
+	assert.Equal(t, "<b>new</b>", s)
+
+	assert.Panics(t, func() { ctx.RenderComponentToString("missing", nil) })
+
+	// execute errors are returned
+	app.Template().Component(template.Must(template.New("bad").Parse(`{{.A.B}}`)))
+	_, err = ctx.RenderComponentToString("bad", map[string]any{"A": "not-a-struct"})
+	assert.Error(t, err)
+}
+
 func TestContextETagOverride(t *testing.T) {
 	t.Parallel()
 

--- a/template.go
+++ b/template.go
@@ -1,6 +1,8 @@
 package hime
 
 import (
+	"encoding/json"
+	"errors"
 	"html/template"
 	"io"
 	"io/fs"
@@ -369,4 +371,33 @@ func cloneTmpl(xs map[string]*tmpl) map[string]*tmpl {
 
 func tfParam(name string, value any) *Param {
 	return &Param{Name: name, Value: value}
+}
+
+// tfDict builds a map from alternating key/value arguments. html/template has
+// no map literal, so this is how multiple values are passed to a component or
+// partial: {{component "card" (dict "title" .T "body" .B)}}.
+func tfDict(v ...any) (map[string]any, error) {
+	if len(v)%2 != 0 {
+		return nil, errors.New("hime: dict requires an even number of arguments")
+	}
+	m := make(map[string]any, len(v)/2)
+	for i := 0; i < len(v); i += 2 {
+		key, ok := v[i].(string)
+		if !ok {
+			return nil, errors.New("hime: dict keys must be strings")
+		}
+		m[key] = v[i+1]
+	}
+	return m, nil
+}
+
+// tfJSON marshals v to JSON for embedding in a script context, e.g.
+// <script>var state = {{json .State}}</script>. The result is marked
+// template.JS; encoding/json escapes <, >, and &, so it is safe inside <script>.
+func tfJSON(v any) (template.JS, error) {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return "", err
+	}
+	return template.JS(b), nil
 }

--- a/template_test.go
+++ b/template_test.go
@@ -443,6 +443,54 @@ func TestTfParam(t *testing.T) {
 	assert.Equal(t, &Param{Name: "id", Value: 1}, tfParam("id", 1))
 }
 
+func TestTfDict(t *testing.T) {
+	m, err := tfDict("a", 1, "b", "x")
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]any{"a": 1, "b": "x"}, m)
+
+	_, err = tfDict("a")
+	assert.Error(t, err) // odd number of args
+
+	_, err = tfDict(1, "v")
+	assert.Error(t, err) // non-string key
+}
+
+func TestTfJSON(t *testing.T) {
+	got, err := tfJSON(map[string]any{"a": 1})
+	assert.NoError(t, err)
+	assert.Equal(t, template.JS(`{"a":1}`), got)
+
+	// <, >, & are escaped so the output can not break out of a <script> tag
+	got, err = tfJSON("</script>")
+	assert.NoError(t, err)
+	assert.NotContains(t, string(got), "</")
+
+	// unmarshalable values propagate the error
+	_, err = tfJSON(make(chan int))
+	assert.Error(t, err)
+}
+
+func TestTemplateDictAndJSONFuncs(t *testing.T) {
+	t.Run("dict passes multiple values to a component", func(t *testing.T) {
+		tp := New().Template()
+		tp.ParseComponent("kv", `{{.k}}={{.v}}`)
+		tp.Parse("t", `{{component "kv" (dict "k" "x" "v" 5)}}`)
+
+		b := bytes.Buffer{}
+		assert.NoError(t, tp.list["t"].Execute(&b, nil))
+		assert.Equal(t, "x=5", b.String())
+	})
+
+	t.Run("json renders trusted in a script context", func(t *testing.T) {
+		tp := New().Template()
+		tp.Parse("t", `<script>var s = {{json .}}</script>`)
+
+		b := bytes.Buffer{}
+		assert.NoError(t, tp.list["t"].Execute(&b, map[string]any{"a": 1}))
+		assert.Equal(t, `<script>var s = {"a":1}</script>`, b.String())
+	})
+}
+
 func TestTemplateComponentMultiple(t *testing.T) {
 	tp := New().Template()
 	tp.Component(


### PR DESCRIPTION
## Summary

Template/component DX helpers for building MPA views (Tier 1 of the website-DX research, part 1 of 2):

- **`dict`** template func — `html/template` has no map literal, so this is how you pass multiple values to a component/partial:
  ```
  {{component "card" (dict "title" .Title "body" .Body)}}
  ```
- **`json`** template func — marshal data to `template.JS` for inline script state (common htmx/MPA pattern). `encoding/json` escapes `<`, `>`, `&`, so it's safe inside `<script>`:
  ```
  <script>var state = {{json .State}}</script>
  ```
- **`Context.RenderComponentToString(name, data) (string, error)`** — renders a component to a string instead of the response, for composing responses (e.g. htmx out-of-band swaps) from several components. Mirrors `Component` (panics if not found; returns execute errors).

All three are thin wrappers over `html/template` / the existing component render path — no new dependencies, no lock-in.

## Test plan
- [x] `go vet ./...`
- [x] `go test ./...` — **100%** coverage on `tfDict`, `tfJSON`, `RenderComponentToString`
- [x] `go test -race ./...`
- [x] `gofmt` clean
- CLAUDE.md updated

Part 2 (htmx Context helpers) will be a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)