### PR TITLE
feat: add htmx Context helpers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,7 @@ Response "results" are methods that write to the response and return `error` (me
 - **`filterRenderError`** swallows broken-pipe / `net.OpError` / `EPIPE` errors so client disconnects aren't treated as handler failures.
 - `request.go` adds typed value helpers that trim spaces and strip commas, in three parallel families — `FormValue*` (query+body), `PostFormValue*` (body), and `QueryValue*` (query only) — plus multi-value slice getters (`FormValues`/`PostFormValues`/`QueryValues`) and `FormFileNotEmpty`/`FormFileHeader`.
 - `cookie.go` adds opt-in signed cookies: a `CookieSigner` interface plus an HMAC-SHA256 reference impl (`NewHMACCookieSigner`). Set `app.CookieSigner` (a public field, like `app.ETag`) to enable `AddSignedCookie`/`SignedCookieValue`, which read the signer off the app and panic if it's unset. The signer binds the cookie name into the MAC and verifies in constant time; it signs but does not encrypt. No lock-in — you supply your own signer.
+- `htmx.go` adds opt-in [htmx](https://htmx.org) helpers on `Context`: `IsHTMX()` (detect the `HX-Request` header), `HTMXRedirect`/`HTMXRefresh`, and chainable `HTMXReswap`/`HTMXRetarget`/`HTMXTrigger` that set `HX-*` response headers. Thin wrappers, no client runtime beyond htmx itself.
 - Rendering buffers come from a shared `sync.Pool` in `pool.go` (`getBytes`/`putBytes`) — reuse it for any new buffered output.
 
 ### Templates and components (`template.go`)

--- a/htmx.go
+++ b/htmx.go
@@ -1,0 +1,63 @@
+package hime
+
+import "encoding/json"
+
+// htmx (https://htmx.org) response/request header helpers. They are thin
+// wrappers over the HX-* headers, opt-in, and require no client runtime beyond
+// htmx itself.
+
+// IsHTMX reports whether the request was made by htmx, via the HX-Request
+// header. Use it to render a partial/component for htmx and a full page
+// otherwise.
+func (ctx *Context) IsHTMX() bool {
+	return ctx.Request.Header.Get("HX-Request") == "true"
+}
+
+// HTMXRedirect instructs htmx to perform a client-side redirect using the
+// HX-Redirect response header. Prefer this over Redirect when responding to an
+// htmx request, since htmx does not follow normal 3xx redirects. params are
+// applied to url the same way as Redirect.
+func (ctx *Context) HTMXRedirect(url string, params ...any) error {
+	ctx.SetHeader("HX-Redirect", buildPath(url, params...))
+	return nil
+}
+
+// HTMXRefresh instructs htmx to do a full page reload via the HX-Refresh header.
+func (ctx *Context) HTMXRefresh() error {
+	ctx.SetHeader("HX-Refresh", "true")
+	return nil
+}
+
+// HTMXReswap overrides how htmx swaps the response (e.g. "outerHTML",
+// "beforeend") via the HX-Reswap header. It returns ctx for chaining.
+func (ctx *Context) HTMXReswap(strategy string) *Context {
+	ctx.SetHeader("HX-Reswap", strategy)
+	return ctx
+}
+
+// HTMXRetarget overrides the element htmx swaps the response into via the
+// HX-Retarget header (a CSS selector). It returns ctx for chaining.
+func (ctx *Context) HTMXRetarget(selector string) *Context {
+	ctx.SetHeader("HX-Retarget", selector)
+	return ctx
+}
+
+// HTMXTrigger triggers client-side events after the swap via the HX-Trigger
+// header. With no detail it sends the bare event name; with one detail value it
+// sends {event: detail} as JSON. It returns ctx for chaining, and panics if
+// detail can not be marshalled or if more than one detail is given.
+func (ctx *Context) HTMXTrigger(event string, detail ...any) *Context {
+	switch len(detail) {
+	case 0:
+		ctx.SetHeader("HX-Trigger", event)
+	case 1:
+		b, err := json.Marshal(map[string]any{event: detail[0]})
+		if err != nil {
+			panicf("htmx trigger: %v", err)
+		}
+		ctx.SetHeader("HX-Trigger", string(b))
+	default:
+		panicf("htmx trigger: want 0-1 detail args, got %d", len(detail))
+	}
+	return ctx
+}

--- a/htmx_test.go
+++ b/htmx_test.go
@@ -1,0 +1,92 @@
+package hime_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/moonrhythm/hime"
+)
+
+func newHTMXContext(htmx bool) (*hime.Context, *httptest.ResponseRecorder) {
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	if htmx {
+		r.Header.Set("HX-Request", "true")
+	}
+	w := httptest.NewRecorder()
+	return hime.NewAppContext(hime.New(), w, r), w
+}
+
+func TestContextIsHTMX(t *testing.T) {
+	t.Parallel()
+
+	ctx, _ := newHTMXContext(true)
+	assert.True(t, ctx.IsHTMX())
+
+	ctx, _ = newHTMXContext(false)
+	assert.False(t, ctx.IsHTMX())
+}
+
+func TestContextHTMXRedirect(t *testing.T) {
+	t.Parallel()
+
+	ctx, w := newHTMXContext(true)
+	assert.NoError(t, ctx.HTMXRedirect("/dashboard"))
+	assert.Equal(t, "/dashboard", w.Header().Get("HX-Redirect"))
+
+	// params are applied like Redirect
+	ctx, w = newHTMXContext(true)
+	assert.NoError(t, ctx.HTMXRedirect("/items", &hime.Param{Name: "page", Value: 2}))
+	assert.Equal(t, "/items?page=2", w.Header().Get("HX-Redirect"))
+}
+
+func TestContextHTMXRefresh(t *testing.T) {
+	t.Parallel()
+
+	ctx, w := newHTMXContext(true)
+	assert.NoError(t, ctx.HTMXRefresh())
+	assert.Equal(t, "true", w.Header().Get("HX-Refresh"))
+}
+
+func TestContextHTMXReswapRetarget(t *testing.T) {
+	t.Parallel()
+
+	ctx, w := newHTMXContext(true)
+	// chainable, composing with a render method
+	assert.NoError(t, ctx.HTMXRetarget("#list").HTMXReswap("outerHTML").String("ok"))
+	assert.Equal(t, "#list", w.Header().Get("HX-Retarget"))
+	assert.Equal(t, "outerHTML", w.Header().Get("HX-Reswap"))
+	assert.Equal(t, "ok", w.Body.String())
+}
+
+func TestContextHTMXTrigger(t *testing.T) {
+	t.Parallel()
+
+	t.Run("bare event name", func(t *testing.T) {
+		t.Parallel()
+		ctx, w := newHTMXContext(true)
+		ctx.HTMXTrigger("itemAdded")
+		assert.Equal(t, "itemAdded", w.Header().Get("HX-Trigger"))
+	})
+
+	t.Run("event with detail as json", func(t *testing.T) {
+		t.Parallel()
+		ctx, w := newHTMXContext(true)
+		ctx.HTMXTrigger("itemAdded", map[string]any{"id": 7})
+		assert.JSONEq(t, `{"itemAdded":{"id":7}}`, w.Header().Get("HX-Trigger"))
+	})
+
+	t.Run("too many detail args panics", func(t *testing.T) {
+		t.Parallel()
+		ctx, _ := newHTMXContext(true)
+		assert.Panics(t, func() { ctx.HTMXTrigger("e", 1, 2) })
+	})
+
+	t.Run("unmarshalable detail panics", func(t *testing.T) {
+		t.Parallel()
+		ctx, _ := newHTMXContext(true)
+		assert.Panics(t, func() { ctx.HTMXTrigger("e", make(chan int)) })
+	})
+}


### PR DESCRIPTION
## Summary

Opt-in [htmx](https://htmx.org) helpers on `Context` (Tier 1 of the website-DX research, part 2 of 2). htmx is squarely in hime's stated MPA mission, yet it shipped zero helpers for it. These are thin wrappers over the `HX-*` headers — no client runtime beyond htmx itself, no lock-in:

- **`IsHTMX() bool`** — detect an htmx request (`HX-Request`), to render a partial vs. a full page.
- **`HTMXRedirect(url, params...) error`** — client-side redirect via `HX-Redirect` (htmx doesn't follow normal 3xx redirects); `params` applied like `Redirect`.
- **`HTMXRefresh() error`** — full page reload via `HX-Refresh`.
- **`HTMXReswap(strategy) *Context`** / **`HTMXRetarget(selector) *Context`** — override the swap strategy / target element; chainable.
- **`HTMXTrigger(event, detail...) *Context`** — trigger client-side events via `HX-Trigger`; with a detail value it sends `{event: detail}` as JSON; chainable.

```go
func deleteItem(ctx *hime.Context) error {
    // ... delete ...
    return ctx.HTMXRetarget("#list").HTMXReswap("outerHTML").Component("list", items)
}
```

The chainable setters return `*Context` and compose with the existing render methods (`Component`, `View`, `String`, …); `HTMXRedirect`/`HTMXRefresh` are terminal and return `error` like `Redirect`. `HTMXTrigger` panics on an unmarshalable detail or more than one detail arg (consistent with hime's panic-on-developer-error style).

## Test plan
- [x] `go vet ./...`
- [x] `go test ./...` — **100%** coverage on all six helpers
- [x] `go test -race ./...`
- [x] `gofmt` clean
- CLAUDE.md updated

Companion to #118 (dict/json/RenderComponentToString); independent branch off master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)