### PR TITLE
feat: add FormState for re-rendering forms after validation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,7 @@ Response "results" are methods that write to the response and return `error` (me
 - `cookie.go` adds opt-in signed cookies: a `CookieSigner` interface plus an HMAC-SHA256 reference impl (`NewHMACCookieSigner`). Set `app.CookieSigner` (a public field, like `app.ETag`) to enable `AddSignedCookie`/`SignedCookieValue`, which read the signer off the app and panic if it's unset. The signer binds the cookie name into the MAC and verifies in constant time; it signs but does not encrypt. No lock-in — you supply your own signer.
 - `htmx.go` adds opt-in [htmx](https://htmx.org) helpers on `Context`: `IsHTMX()` (detect the `HX-Request` header), `HTMXRedirect`/`HTMXRefresh`, and chainable `HTMXReswap`/`HTMXRetarget`/`HTMXTrigger` that set `HX-*` response headers. Thin wrappers, no client runtime beyond htmx itself.
 - `flash.go` adds stateless flash messages (`AddFlash`/`Flashes`) for the post/redirect/get pattern, carried in a plain base64-JSON cookie (`flash`) that's cleared on read. Unsigned — non-sensitive UX only; the `flash` field on `Context` accumulates outgoing messages within a request.
+- `form.go` adds `ctx.FormState()` → a `*FormState` holding submitted values (copied from the parsed form) plus per-field validation errors (`Value`/`Values`/`SetValue`/`AddError`/`Error`/`Errors`/`HasError`/`HasErrors`), for re-rendering a form after a failed submission.
 - Rendering buffers come from a shared `sync.Pool` in `pool.go` (`getBytes`/`putBytes`) — reuse it for any new buffered output.
 
 ### Templates and components (`template.go`)

--- a/example_test.go
+++ b/example_test.go
@@ -150,6 +150,20 @@ func ExampleSafeRedirectPath() {
 	// Output: /account
 }
 
+func ExampleContext_FormState() {
+	r := httptest.NewRequest(http.MethodPost, "/", strings.NewReader("email=bad"))
+	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	ctx := hime.NewAppContext(hime.New(), httptest.NewRecorder(), r)
+
+	form := ctx.FormState()
+	if !strings.Contains(form.Value("email"), "@") {
+		form.AddError("email", "invalid email")
+	}
+	// on error, pass form to the view to re-render with the value + message
+	fmt.Println(form.Value("email"), form.HasErrors(), form.Error("email"))
+	// Output: bad true invalid email
+}
+
 func ExampleHMACCookieSigner() {
 	signer := hime.NewHMACCookieSigner([]byte("a-32-byte-or-longer-secret-key!!"))
 

--- a/form.go
+++ b/form.go
@@ -1,0 +1,80 @@
+package hime
+
+import "net/url"
+
+// FormState holds submitted form values together with per-field validation
+// errors, so a form can be re-rendered with the user's input after a failed
+// submission (instead of making them retype everything).
+type FormState struct {
+	values url.Values
+	errors map[string][]string
+}
+
+// FormState returns a FormState seeded with the request's form values (query
+// and body). Add validation errors with AddError, then pass it to a view to
+// re-render the form.
+func (ctx *Context) FormState() *FormState {
+	if ctx.Request.Form == nil {
+		ctx.Request.ParseMultipartForm(defaultMaxMemory)
+	}
+
+	// copy, so SetValue does not mutate the request's parsed form
+	values := make(url.Values, len(ctx.Request.Form))
+	for k, vs := range ctx.Request.Form {
+		values[k] = append([]string(nil), vs...)
+	}
+
+	return &FormState{
+		values: values,
+		errors: map[string][]string{},
+	}
+}
+
+// Value returns the first submitted value for name, or "".
+func (fs *FormState) Value(name string) string {
+	if vs := fs.values[name]; len(vs) > 0 {
+		return vs[0]
+	}
+	return ""
+}
+
+// Values returns all submitted values for name (for multi-value fields such as
+// checkboxes or multi-selects).
+func (fs *FormState) Values(name string) []string {
+	return fs.values[name]
+}
+
+// SetValue sets name's value, replacing any submitted value. Useful for
+// pre-filling a form (such as an edit form) before rendering.
+func (fs *FormState) SetValue(name, value string) {
+	fs.values.Set(name, value)
+}
+
+// AddError records a validation error message for the field name. Calls
+// accumulate.
+func (fs *FormState) AddError(name, message string) {
+	fs.errors[name] = append(fs.errors[name], message)
+}
+
+// Error returns the first error message for name, or "".
+func (fs *FormState) Error(name string) string {
+	if es := fs.errors[name]; len(es) > 0 {
+		return es[0]
+	}
+	return ""
+}
+
+// Errors returns all error messages for name.
+func (fs *FormState) Errors(name string) []string {
+	return fs.errors[name]
+}
+
+// HasError reports whether name has any error.
+func (fs *FormState) HasError(name string) bool {
+	return len(fs.errors[name]) > 0
+}
+
+// HasErrors reports whether any field has an error.
+func (fs *FormState) HasErrors() bool {
+	return len(fs.errors) > 0
+}

--- a/form_test.go
+++ b/form_test.go
@@ -1,0 +1,72 @@
+package hime_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/moonrhythm/hime"
+)
+
+func newFormContext(body string) *hime.Context {
+	r := httptest.NewRequest(http.MethodPost, "/?q=z", strings.NewReader(body))
+	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	return hime.NewAppContext(hime.New(), httptest.NewRecorder(), r)
+}
+
+func TestFormStateValues(t *testing.T) {
+	t.Parallel()
+
+	fs := newFormContext("email=a@b.com&tag=x&tag=y").FormState()
+
+	assert.Equal(t, "a@b.com", fs.Value("email"))
+	assert.Equal(t, []string{"x", "y"}, fs.Values("tag"))
+	assert.Equal(t, "z", fs.Value("q")) // query values are included
+	assert.Equal(t, "", fs.Value("missing"))
+	assert.Empty(t, fs.Values("missing"))
+}
+
+func TestFormStateErrors(t *testing.T) {
+	t.Parallel()
+
+	fs := newFormContext("email=bad").FormState()
+
+	assert.False(t, fs.HasErrors())
+	assert.False(t, fs.HasError("email"))
+	assert.Equal(t, "", fs.Error("email"))
+	assert.Empty(t, fs.Errors("email"))
+
+	fs.AddError("email", "is taken")
+	fs.AddError("email", "is invalid")
+
+	assert.True(t, fs.HasErrors())
+	assert.True(t, fs.HasError("email"))
+	assert.False(t, fs.HasError("name"))
+	assert.Equal(t, "is taken", fs.Error("email"))
+	assert.Equal(t, []string{"is taken", "is invalid"}, fs.Errors("email"))
+}
+
+func TestFormStateSetValue(t *testing.T) {
+	t.Parallel()
+
+	fs := newFormContext("email=a@b.com").FormState()
+	fs.SetValue("email", "c@d.com")
+	fs.SetValue("name", "hime")
+
+	assert.Equal(t, "c@d.com", fs.Value("email"))
+	assert.Equal(t, "hime", fs.Value("name"))
+}
+
+func TestFormStateDoesNotMutateRequest(t *testing.T) {
+	t.Parallel()
+
+	ctx := newFormContext("email=a@b.com")
+	fs := ctx.FormState()
+	fs.SetValue("email", "changed")
+
+	// the request's own form value is untouched by the copy
+	assert.Equal(t, "a@b.com", ctx.FormValue("email"))
+}


### PR DESCRIPTION
## Summary

Tier-2 website-DX: `ctx.FormState()` returns a `*FormState` that holds the submitted form values together with per-field validation errors, so a form can be re-rendered with the user's input after a failed submission (instead of making them retype).

```go
func signup(ctx *hime.Context) error {
    form := ctx.FormState()
    if !strings.Contains(form.Value("email"), "@") {
        form.AddError("email", "Enter a valid email")
    }
    if form.HasErrors() {
        return ctx.View("signup", map[string]any{"Form": form})
    }
    // ... create the account ...
    return ctx.Redirect("/welcome")
}
```
```html
<input name="email" value="{{.Form.Value "email"}}">
{{if .Form.HasError "email"}}<span class="err">{{.Form.Error "email"}}</span>{{end}}
```

### API
- **Values:** `Value(name)`, `Values(name)`, `SetValue(name, value)` (pre-fill, e.g. an edit form)
- **Errors:** `AddError(name, msg)`, `Error(name)` (first), `Errors(name)` (all), `HasError(name)`, `HasErrors()`

## Design notes (open to redirection)
- **Handler-passes-to-view**, no per-request template funcs — keeps it self-contained (unlike `isRoute`, which still needs that enabler).
- **Values are copied** from the parsed form, so `SetValue` never mutates `ctx.Request.Form` (tested).
- Seeded from query **and** body (matching `ctx.FormValue`); uses `ParseMultipartForm`, so it works for urlencoded and multipart text fields.
- **Categorized, multi-error** (`map[string][]string`) — a field can carry several messages.

## Test plan
- [x] `go vet ./...`
- [x] `go test ./...` — **100%** coverage on all 10 `FormState` functions (incl. the no-mutation guarantee)
- [x] `go test -race ./...`
- [x] `gofmt` clean
- runnable `ExampleContext_FormState`; CLAUDE.md updated

## Tier-2 status
This leaves **`isRoute`** as the last Tier-2 item — gated on the per-request template-funcs enabler decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)