### PR TITLE
docs: modernize CSRF guidance for SameSite era

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Notes:
   <meta name="htmx-config" content='{"responseHandling":[{"code":"422","swap":true},{"code":"204","swap":false},{"code":"[23]..","swap":true},{"code":"[45]..","swap":false,"error":true}]}'>
   ```
 
-- CSRF: set `SameSite=Lax` (or `Strict`) explicitly on your session cookie and never mutate state on GET — that alone stops classic cross-site form CSRF in modern browsers. For defense-in-depth (untrusted subdomains are still "same-site"), reject mutating requests whose `Sec-Fetch-Site` header is cross-origin — a few lines of your own middleware; hime ships none. If you use token middleware anyway, wire it with `hx-headers`, e.g. `<body hx-headers='{"X-CSRF-Token": "{{.Token}}"}'>`, and prefer per-session tokens (or set `hx-history="false"`) since htmx snapshots pages into localStorage.
+- CSRF: set `SameSite=Lax` (or `Strict`) explicitly on your session cookie and never mutate state on GET — that alone stops classic cross-site form CSRF in modern browsers. For defense-in-depth (untrusted subdomains are still "same-site"), wrap your handler with the standard library's [`http.NewCrossOriginProtection`](https://pkg.go.dev/net/http#CrossOriginProtection): `app.Handler(cop.Handler(mux))` — hime adds nothing because it composes directly. If you use token middleware anyway, wire it with `hx-headers`, e.g. `<body hx-headers='{"X-CSRF-Token": "{{.Token}}"}'>`, and prefer per-session tokens (or set `hx-history="false"`) since htmx snapshots pages into localStorage.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Notes:
   <meta name="htmx-config" content='{"responseHandling":[{"code":"422","swap":true},{"code":"204","swap":false},{"code":"[23]..","swap":true},{"code":"[45]..","swap":false,"error":true}]}'>
   ```
 
-- CSRF: hime ships no CSRF middleware — wire your token with `hx-headers`, e.g. `<body hx-headers='{"X-CSRF-Token": "{{.Token}}"}'>`. Use per-session (not per-request) tokens, or set `hx-history="false"`, since htmx snapshots pages into localStorage.
+- CSRF: set `SameSite=Lax` (or `Strict`) explicitly on your session cookie and never mutate state on GET — that alone stops classic cross-site form CSRF in modern browsers. For defense-in-depth (untrusted subdomains are still "same-site"), reject mutating requests whose `Sec-Fetch-Site` header is cross-origin — a few lines of your own middleware; hime ships none. If you use token middleware anyway, wire it with `hx-headers`, e.g. `<body hx-headers='{"X-CSRF-Token": "{{.Token}}"}'>`, and prefer per-session tokens (or set `hx-history="false"`) since htmx snapshots pages into localStorage.
 
 ## License
 


### PR DESCRIPTION
Follow-up to #123. The README's htmx CSRF note prescribed token middleware as the default. Modern guidance:

- An **explicitly set** `SameSite=Lax`/`Strict` session cookie + never mutating on GET stops classic cross-site form CSRF in all modern browsers (explicit matters: default-Lax carries the Chrome Lax+POST grace window and isn't uniform across Safari/Firefox).
- Remaining gap is same-site-but-cross-origin (subdomain takeover, user content on subdomains) — covered by rejecting mutating requests with a cross-origin `Sec-Fetch-Site`, a few lines of BYO middleware, which fits hime's philosophy better than token machinery.
- Token middleware is demoted to "if you use it anyway", keeping the `hx-headers` wiring and the localStorage-snapshot caveat.